### PR TITLE
[Backend] OnlyOffice document.key 관리 로직 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,10 @@ PDF 파일은 자동으로 `edit: false`로 설정되어 읽기 전용 모드로
 - Community Edition: AGPLv3
 - Enterprise Edition: 상용 라이선스
 
+## 문서
+
+- [OnlyOffice 통합 가이드](docs/onlyoffice-integration-guide.md) - document.key 관리, callback 처리 등 기술 상세
+
 ## 참고 자료
 
 - [ONLYOFFICE API Documentation](https://api.onlyoffice.com/editors/basic)

--- a/backend/src/main/java/com/example/onlyoffice/controller/EditorController.java
+++ b/backend/src/main/java/com/example/onlyoffice/controller/EditorController.java
@@ -3,17 +3,18 @@ package com.example.onlyoffice.controller;
 import com.example.onlyoffice.service.DocumentService;
 import com.example.onlyoffice.util.JwtManager;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
 @Controller
 @RequiredArgsConstructor
+@Slf4j
 public class EditorController {
 
     private final DocumentService documentService;
@@ -25,11 +26,12 @@ public class EditorController {
     @GetMapping("/api/config")
     @org.springframework.web.bind.annotation.ResponseBody
     public Map<String, Object> getEditorConfig(@RequestParam("fileName") String fileName) {
-        File file = documentService.getFile(fileName);
-
         String serverUrl = documentService.getServerUrl();
         String fileExtension = getFileExtension(fileName);
         String documentType = getDocumentType(fileExtension);
+
+        // Service를 통해 editorKey 생성
+        String editorKey = documentService.getEditorKey(fileName);
 
         Map<String, Object> config = new HashMap<>();
         config.put("documentType", documentType);
@@ -39,7 +41,7 @@ public class EditorController {
         document.put("title", fileName);
         document.put("url", serverUrl + "/files/" + fileName);
         document.put("fileType", fileExtension);
-        document.put("key", fileName + "_" + file.lastModified());
+        document.put("key", editorKey);
 
         Map<String, Object> permissions = new HashMap<>();
         permissions.put("edit", true);
@@ -66,6 +68,7 @@ public class EditorController {
         response.put("config", config);
         response.put("documentServerUrl", onlyofficeUrl);
 
+        log.info("Editor config generated for file: {}, key: {}", fileName, editorKey);
         return response;
     }
 

--- a/backend/src/main/java/com/example/onlyoffice/repository/DocumentRepository.java
+++ b/backend/src/main/java/com/example/onlyoffice/repository/DocumentRepository.java
@@ -22,6 +22,16 @@ import java.util.Optional;
 @Repository
 public interface DocumentRepository extends JpaRepository<Document, Long> {
 
+
+    /**
+     * 파일명으로 문서 조회 (soft delete된 문서 제외)
+     * EditorController에서 에디터 설정 생성 시 사용
+     *
+     * @param fileName 파일명
+     * @return 문서가 존재하고 삭제되지 않았으면 해당 문서를 포함한 Optional
+     */
+    Optional<Document> findByFileNameAndDeletedAtIsNull(String fileName);
+
     // ==================== 기본 조회 메서드 ====================
 
     /**

--- a/backend/src/main/java/com/example/onlyoffice/service/DocumentService.java
+++ b/backend/src/main/java/com/example/onlyoffice/service/DocumentService.java
@@ -1,25 +1,33 @@
 package com.example.onlyoffice.service;
 
+import com.example.onlyoffice.entity.Document;
+import com.example.onlyoffice.repository.DocumentRepository;
+import com.example.onlyoffice.util.KeyUtils;
 import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class DocumentService {
+
+    private final DocumentRepository documentRepository;
 
     @Value("${storage.path}")
     private String storagePath;
@@ -39,6 +47,8 @@ public class DocumentService {
             throw new RuntimeException("Could not initialize storage", e);
         }
     }
+
+    // ==================== 파일 시스템 작업 ====================
 
     public List<String> listFiles() {
         try (Stream<Path> walk = Files.walk(this.rootLocation, 1)) {
@@ -68,7 +78,79 @@ public class DocumentService {
     }
 
     public String getServerUrl() {
-        // Return the configurable base URL (e.g., http://host.docker.internal:8080)
         return serverBaseUrl;
+    }
+
+    // ==================== ONLYOFFICE document.key 관련 ====================
+
+    /**
+     * ONLYOFFICE document.key 생성
+     * DB에 문서가 있으면 DB 기반 key 사용, 없으면 파일시스템 기반 fallback
+     *
+     * @param fileName 파일명
+     * @return 유효한 document.key
+     */
+    public String getEditorKey(String fileName) {
+        File file = getFile(fileName);
+
+        return documentRepository.findByFileNameAndDeletedAtIsNull(fileName)
+            .map(doc -> {
+                String key = KeyUtils.generateEditorKey(doc.getFileKey(), doc.getEditorVersion());
+                log.debug("Using DB-based key for {}: {}", fileName, key);
+                return key;
+            })
+            .orElseGet(() -> {
+                // DB에 문서가 없으면 파일시스템 기반 fallback (하위 호환성)
+                String fallbackKey = KeyUtils.sanitize(fileName + "_" + file.lastModified());
+                log.warn("Document not found in DB for {}, using fallback key: {}", fileName, fallbackKey);
+                return fallbackKey;
+            });
+    }
+
+    /**
+     * 파일명으로 문서 조회
+     *
+     * @param fileName 파일명
+     * @return 문서 Optional
+     */
+    public Optional<Document> findByFileName(String fileName) {
+        return documentRepository.findByFileNameAndDeletedAtIsNull(fileName);
+    }
+
+    /**
+     * 문서 저장 후 editorVersion 증가
+     * 편집 종료(status=2) 시 호출하여 다음 편집 세션을 위한 새 key 생성
+     *
+     * @param fileName 파일명
+     */
+    public void incrementEditorVersion(String fileName) {
+        documentRepository.findByFileNameAndDeletedAtIsNull(fileName)
+            .ifPresentOrElse(
+                doc -> {
+                    int oldVersion = doc.getEditorVersion();
+                    doc.incrementEditorVersion();
+                    documentRepository.save(doc);
+                    log.info("Editor version incremented for {}: {} -> {}",
+                        fileName, oldVersion, doc.getEditorVersion());
+                },
+                () -> log.warn("Document not found in DB for version increment: {}", fileName)
+            );
+    }
+
+    /**
+     * URL에서 편집된 문서 다운로드 및 저장
+     *
+     * @param downloadUrl ONLYOFFICE에서 제공한 다운로드 URL
+     * @param fileName 저장할 파일명
+     */
+    public void saveDocumentFromUrl(String downloadUrl, String fileName) {
+        log.info("Downloading file from {} to {}", downloadUrl, fileName);
+        try (InputStream in = URI.create(downloadUrl).toURL().openStream()) {
+            saveFile(fileName, in);
+            log.info("File saved successfully: {}", fileName);
+        } catch (Exception e) {
+            log.error("Error downloading file from {}", downloadUrl, e);
+            throw new RuntimeException("Failed to save document from URL", e);
+        }
     }
 }

--- a/backend/src/main/java/com/example/onlyoffice/util/KeyUtils.java
+++ b/backend/src/main/java/com/example/onlyoffice/util/KeyUtils.java
@@ -1,0 +1,126 @@
+package com.example.onlyoffice.util;
+
+import org.springframework.util.DigestUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Pattern;
+
+/**
+ * ONLYOFFICE document.key 생성 및 검증 유틸리티.
+ *
+ * OnlyOffice 스펙:
+ * - key 최대 길이: 128자
+ * - 특수문자 사용 불가 (영문, 숫자, _, - 만 허용)
+ * - 저장 시마다 새로운 key 생성 필요
+ */
+public final class KeyUtils {
+
+    /**
+     * OnlyOffice document.key 최대 길이
+     */
+    public static final int MAX_KEY_LENGTH = 128;
+
+    /**
+     * 허용되는 문자 패턴 (영문, 숫자, _, -)
+     */
+    private static final Pattern SAFE_CHARS_PATTERN = Pattern.compile("[^a-zA-Z0-9_-]");
+
+    /**
+     * 해시 길이 (MD5 일부 사용)
+     */
+    private static final int HASH_LENGTH = 16;
+
+    private KeyUtils() {
+        // 유틸리티 클래스 - 인스턴스화 방지
+    }
+
+    /**
+     * 안전한 document.key 생성
+     *
+     * @param fileKey 파일 고유 식별자 (referenceData.fileKey)
+     * @param version 편집 세션 버전
+     * @return OnlyOffice 스펙에 맞는 안전한 key
+     */
+    public static String generateEditorKey(String fileKey, int version) {
+        if (fileKey == null || fileKey.isBlank()) {
+            throw new IllegalArgumentException("fileKey cannot be null or blank");
+        }
+
+        String raw = fileKey + "_v" + version;
+        String safe = sanitize(raw);
+
+        if (safe.length() > MAX_KEY_LENGTH) {
+            // 길이 초과 시 해시 기반 축약
+            return generateHashBasedKey(fileKey, version);
+        }
+
+        return safe;
+    }
+
+    /**
+     * 특수문자 제거
+     *
+     * @param input 원본 문자열
+     * @return 안전한 문자만 포함된 문자열
+     */
+    public static String sanitize(String input) {
+        if (input == null) {
+            return "";
+        }
+        return SAFE_CHARS_PATTERN.matcher(input).replaceAll("");
+    }
+
+    /**
+     * key가 유효한지 검증
+     *
+     * @param key 검증할 key
+     * @return 유효하면 true
+     */
+    public static boolean isValidKey(String key) {
+        if (key == null || key.isBlank()) {
+            return false;
+        }
+        if (key.length() > MAX_KEY_LENGTH) {
+            return false;
+        }
+        // 허용되지 않는 문자가 있는지 확인
+        return !SAFE_CHARS_PATTERN.matcher(key).find();
+    }
+
+    /**
+     * 해시 기반 축약 key 생성
+     * 긴 fileKey를 MD5 해시로 축약
+     *
+     * @param fileKey 파일 고유 식별자
+     * @param version 편집 세션 버전
+     * @return 해시 기반 축약 key
+     */
+    private static String generateHashBasedKey(String fileKey, int version) {
+        String hash = DigestUtils.md5DigestAsHex(
+            fileKey.getBytes(StandardCharsets.UTF_8)
+        ).substring(0, HASH_LENGTH);
+
+        return hash + "_v" + version;
+    }
+
+    /**
+     * 파일명과 타임스탬프로 fileKey 생성 (신규 문서용)
+     *
+     * @param fileName 파일명
+     * @param timestamp 생성 시각 (밀리초)
+     * @return 고유한 fileKey
+     */
+    public static String generateFileKey(String fileName, long timestamp) {
+        String base = sanitize(fileName) + "_" + timestamp;
+
+        if (base.length() > MAX_KEY_LENGTH - 10) {
+            // 버전 접미사 공간 확보
+            String hash = DigestUtils.md5DigestAsHex(
+                fileName.getBytes(StandardCharsets.UTF_8)
+            ).substring(0, HASH_LENGTH);
+            return hash + "_" + timestamp;
+        }
+
+        return base;
+    }
+}

--- a/backend/src/test/java/com/example/onlyoffice/util/KeyUtilsTest.java
+++ b/backend/src/test/java/com/example/onlyoffice/util/KeyUtilsTest.java
@@ -1,0 +1,170 @@
+package com.example.onlyoffice.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("KeyUtils")
+class KeyUtilsTest {
+
+    @Nested
+    @DisplayName("generateEditorKey")
+    class GenerateEditorKey {
+
+        @Test
+        @DisplayName("정상적인 fileKey와 version으로 key 생성")
+        void shouldGenerateKeyFromFileKeyAndVersion() {
+            // given
+            String fileKey = "doc123";
+            int version = 5;
+
+            // when
+            String result = KeyUtils.generateEditorKey(fileKey, version);
+
+            // then
+            assertThat(result).isEqualTo("doc123_v5");
+        }
+
+        @Test
+        @DisplayName("생성된 key는 128자 이하")
+        void shouldGenerateKeyWithinMaxLength() {
+            // given
+            String longFileKey = "a".repeat(200);
+            int version = 999;
+
+            // when
+            String result = KeyUtils.generateEditorKey(longFileKey, version);
+
+            // then
+            assertThat(result.length()).isLessThanOrEqualTo(KeyUtils.MAX_KEY_LENGTH);
+        }
+
+        @Test
+        @DisplayName("null fileKey는 예외 발생")
+        void shouldThrowExceptionForNullFileKey() {
+            assertThatThrownBy(() -> KeyUtils.generateEditorKey(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("fileKey cannot be null");
+        }
+
+        @Test
+        @DisplayName("빈 fileKey는 예외 발생")
+        void shouldThrowExceptionForBlankFileKey() {
+            assertThatThrownBy(() -> KeyUtils.generateEditorKey("  ", 1))
+                .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("sanitize")
+    class Sanitize {
+
+        @Test
+        @DisplayName("특수문자 제거")
+        void shouldRemoveSpecialCharacters() {
+            // given
+            String input = "file@name#with$special%chars!";
+
+            // when
+            String result = KeyUtils.sanitize(input);
+
+            // then
+            assertThat(result).isEqualTo("filenamewithspecialchars");
+        }
+
+        @Test
+        @DisplayName("허용된 문자는 유지")
+        void shouldKeepAllowedCharacters() {
+            // given
+            String input = "file_name-123";
+
+            // when
+            String result = KeyUtils.sanitize(input);
+
+            // then
+            assertThat(result).isEqualTo("file_name-123");
+        }
+
+        @Test
+        @DisplayName("null 입력시 빈 문자열 반환")
+        void shouldReturnEmptyStringForNull() {
+            assertThat(KeyUtils.sanitize(null)).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("isValidKey")
+    class IsValidKey {
+
+        @Test
+        @DisplayName("유효한 key는 true 반환")
+        void shouldReturnTrueForValidKey() {
+            assertThat(KeyUtils.isValidKey("doc123_v5")).isTrue();
+            assertThat(KeyUtils.isValidKey("file-name_v1")).isTrue();
+        }
+
+        @Test
+        @DisplayName("null은 false 반환")
+        void shouldReturnFalseForNull() {
+            assertThat(KeyUtils.isValidKey(null)).isFalse();
+        }
+
+        @Test
+        @DisplayName("빈 문자열은 false 반환")
+        void shouldReturnFalseForBlank() {
+            assertThat(KeyUtils.isValidKey("")).isFalse();
+            assertThat(KeyUtils.isValidKey("  ")).isFalse();
+        }
+
+        @Test
+        @DisplayName("128자 초과는 false 반환")
+        void shouldReturnFalseForTooLongKey() {
+            String longKey = "a".repeat(129);
+            assertThat(KeyUtils.isValidKey(longKey)).isFalse();
+        }
+
+        @Test
+        @DisplayName("특수문자 포함시 false 반환")
+        void shouldReturnFalseForSpecialCharacters() {
+            assertThat(KeyUtils.isValidKey("doc@123")).isFalse();
+            assertThat(KeyUtils.isValidKey("file#name")).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("generateFileKey")
+    class GenerateFileKey {
+
+        @Test
+        @DisplayName("파일명과 타임스탬프로 fileKey 생성")
+        void shouldGenerateFileKeyFromFileNameAndTimestamp() {
+            // given
+            String fileName = "document.docx";
+            long timestamp = 1234567890L;
+
+            // when
+            String result = KeyUtils.generateFileKey(fileName, timestamp);
+
+            // then
+            assertThat(result).isEqualTo("documentdocx_1234567890");
+        }
+
+        @Test
+        @DisplayName("긴 파일명은 해시로 축약")
+        void shouldHashLongFileName() {
+            // given
+            String longFileName = "a".repeat(200) + ".docx";
+            long timestamp = 1234567890L;
+
+            // when
+            String result = KeyUtils.generateFileKey(longFileName, timestamp);
+
+            // then
+            assertThat(result.length()).isLessThanOrEqualTo(KeyUtils.MAX_KEY_LENGTH);
+            assertThat(result).contains("_1234567890");
+        }
+    }
+}

--- a/docs/onlyoffice-integration-guide.md
+++ b/docs/onlyoffice-integration-guide.md
@@ -1,0 +1,286 @@
+# OnlyOffice Document Server 통합 가이드
+
+이 문서는 OnlyOffice Document Server API 스펙과 현재 구현 상태를 정리한 기술 문서입니다.
+
+## 목차
+
+- [핵심 개념](#핵심-개념)
+- [document.key 관리](#documentkey-관리)
+- [Callback Handler](#callback-handler)
+- [현재 구현 분석](#현재-구현-분석)
+- [개선 필요 사항](#개선-필요-사항)
+- [참고 자료](#참고-자료)
+
+---
+
+## 핵심 개념
+
+### Key의 두 가지 유형
+
+OnlyOffice에는 두 가지 key 개념이 존재합니다:
+
+| 구분 | `document.key` | `referenceData.fileKey` |
+|------|----------------|-------------------------|
+| **용도** | 편집 세션 식별 | 파일 영구 식별 |
+| **변경 시점** | 저장할 때마다 새로 생성 | 불변 (파일 생성 시 1회) |
+| **역할** | 에디터 캐시 관리, co-editing 세션 공유 | 외부 데이터 참조, 파일 링크 |
+
+### document.key 상세
+
+```
+document.key는 문서를 인식하기 위해 서비스가 사용하는 고유 문서 식별자입니다.
+알려진 key가 전송되면 문서는 캐시에서 가져옵니다.
+문서가 편집되고 저장될 때마다 key는 새로 생성되어야 합니다.
+```
+
+**제약사항:**
+- 최대 길이: **128자**
+- 특수문자: **사용 불가** (영문, 숫자, `_`, `-` 권장)
+- 고유성: 동일 Document Server에 연결된 모든 서비스에서 고유해야 함
+
+---
+
+## document.key 관리
+
+### Key 생성 규칙
+
+```java
+// 권장 패턴
+String key = fileId + "_v" + version;  // 예: "doc123_v5"
+
+// 또는 해시 기반
+String key = hash(fileId + lastModified);
+```
+
+### Key 변경 시점
+
+| 상황 | Key 변경 여부 | 설명 |
+|------|--------------|------|
+| 문서 열기 | 유지 | 동일 key로 co-editing 세션 참여 |
+| 편집 중 (status 1) | 유지 | 세션 유지 |
+| Force Save (status 6) | **유지** | 세션 중 저장, key 변경 금지 |
+| 편집 종료 저장 (status 2) | **변경** | 다음 편집을 위해 새 key 생성 |
+| 변경 없이 닫기 (status 4) | 유지 | 저장 발생 안 함 |
+
+### Co-editing과 Key
+
+```
+동일한 key를 가진 사용자들은 같은 문서를 co-editing 합니다.
+다른 key를 사용하면 완전히 별개의 파일로 인식됩니다.
+```
+
+**예시 시나리오:**
+1. User A가 `key: doc1_v3`으로 문서 열기
+2. User B가 `key: doc1_v3`으로 문서 열기 → **co-editing 시작**
+3. User A가 저장 후 종료 → 서버에서 `doc1_v4`로 버전 증가
+4. User C가 `key: doc1_v4`로 문서 열기 → 최신 버전으로 새 세션
+
+---
+
+## Callback Handler
+
+### Callback Status 코드
+
+| Status | 의미 | 처리 방법 |
+|--------|------|----------|
+| **1** | 편집 중 | 사용자 접속/해제 알림, 처리 불필요 |
+| **2** | 저장 완료 (편집 종료) | 파일 다운로드 & 저장, **key 갱신** |
+| **3** | 저장 에러 | 에러 로깅 |
+| **4** | 변경 없이 닫힘 | 처리 불필요 |
+| **6** | Force Save | 파일 다운로드 & 저장, key 유지 |
+| **7** | Force Save 에러 | 에러 로깅 |
+
+### Callback 요청 예시
+
+**Status 2 (저장 완료):**
+```json
+{
+  "key": "doc123_v3",
+  "status": 2,
+  "url": "https://documentserver/cache/edited-file.docx",
+  "changesurl": "https://documentserver/cache/changes.zip",
+  "history": {
+    "changes": [...],
+    "serverVersion": "7.5.0"
+  },
+  "users": ["user1"],
+  "actions": [{"type": 0, "userid": "user1"}]
+}
+```
+
+### Callback 응답
+
+```json
+{"error": 0}  // 성공
+{"error": 1}  // 실패
+```
+
+---
+
+## 현재 구현 분석
+
+### 아키텍처
+
+```
+┌─────────────┐     ┌─────────────┐     ┌─────────────┐
+│  Frontend   │────▶│   Backend   │────▶│ OnlyOffice  │
+│  (Next.js)  │     │(Spring Boot)│     │   Server    │
+└─────────────┘     └──────┬──────┘     └─────────────┘
+                           │
+                    ┌──────┴──────┐
+                    │  PostgreSQL │
+                    │   + MinIO   │
+                    └─────────────┘
+```
+
+### 주요 컴포넌트
+
+| 파일 | 역할 |
+|------|------|
+| `EditorController.java` | 에디터 설정 JSON 생성, key 생성 |
+| `CallbackController.java` | OnlyOffice callback 처리, 파일 저장 |
+| `DocumentService.java` | 파일 I/O 처리 |
+| `Document.java` | 문서 엔티티 (JPA) |
+
+### 현재 Key 생성 방식
+
+```java
+// EditorController.java:40
+document.put("key", fileName + "_" + file.lastModified());
+```
+
+**문제점:**
+- 파일시스템의 `lastModified` 의존
+- DB 엔티티와 연동되지 않음
+- 저장 후 명시적 갱신 로직 없음
+
+### 현재 Callback 처리
+
+```java
+// CallbackController.java
+if (status == 2 || status == 6) {
+    // 파일 다운로드 및 저장
+    documentService.saveFile(fileName, inputStream);
+    // ❌ key 갱신 로직 없음
+}
+```
+
+---
+
+## 개선 필요 사항
+
+### Issue #23 참조
+
+자세한 내용은 [GitHub Issue #23](https://github.com/taez224/onlyoffice-demo/issues/23) 참조
+
+### 1. Document 엔티티 확장
+
+```java
+@Entity
+public class Document {
+    // 기존 필드
+    @Column(name = "file_key", unique = true)
+    private String fileKey;  // 불변 - referenceData용
+
+    // 추가 필드
+    @Column(name = "editor_version")
+    private Integer editorVersion = 0;  // 편집 세션 버전
+
+    public String getEditorKey() {
+        return fileKey + "_v" + editorVersion;
+    }
+
+    public void incrementEditorVersion() {
+        this.editorVersion++;
+    }
+}
+```
+
+### 2. EditorController 수정
+
+```java
+@GetMapping("/api/config")
+public Map<String, Object> getEditorConfig(@RequestParam String fileName) {
+    Document doc = documentRepository.findByFileName(fileName)
+        .orElseThrow(() -> new NotFoundException("Document not found"));
+
+    // DB 기반 key 생성
+    String key = doc.getEditorKey();  // fileKey + "_v" + version
+
+    // 길이 검증
+    if (key.length() > 128) {
+        key = generateSafeKey(doc);
+    }
+
+    document.put("key", key);
+    // ...
+}
+```
+
+### 3. CallbackController 수정
+
+```java
+@PostMapping("/callback")
+public Map<String, Object> callback(...) {
+    if (status == 2) {  // 편집 종료 & 저장 완료
+        // 파일 저장
+        documentService.saveFile(fileName, inputStream);
+
+        // key 갱신 (다음 편집을 위해)
+        Document doc = documentRepository.findByFileName(fileName).orElseThrow();
+        doc.incrementEditorVersion();
+        documentRepository.save(doc);
+
+        log.info("Document saved, new version: {}", doc.getEditorVersion());
+    }
+
+    if (status == 6) {  // Force Save
+        // 파일만 저장, key 유지
+        documentService.saveFile(fileName, inputStream);
+    }
+
+    return Map.of("error", 0);
+}
+```
+
+### 4. Key 유틸리티
+
+```java
+public class KeyUtils {
+    private static final int MAX_KEY_LENGTH = 128;
+    private static final Pattern SAFE_CHARS = Pattern.compile("[^a-zA-Z0-9_-]");
+
+    public static String generateSafeKey(String base, int version) {
+        String raw = base + "_v" + version;
+        String safe = SAFE_CHARS.matcher(raw).replaceAll("");
+
+        if (safe.length() > MAX_KEY_LENGTH) {
+            // 해시 기반 축약
+            String hash = DigestUtils.md5Hex(base).substring(0, 16);
+            safe = hash + "_v" + version;
+        }
+
+        return safe;
+    }
+}
+```
+
+---
+
+## 참고 자료
+
+### 공식 문서
+
+- [document.key 스펙](https://api.onlyoffice.com/docs/docs-api/usage-api/config/document/document/#key)
+- [Callback Handler](https://api.onlyoffice.com/docs/docs-api/usage-api/callback-handler/)
+- [Co-editing 가이드](https://api.onlyoffice.com/docs/docs-api/get-started/how-it-works/co-editing/)
+- [referenceData 스펙](https://api.onlyoffice.com/docs/docs-api/usage-api/config/document/document/#referencedata)
+- [Troubleshooting](https://api.onlyoffice.com/docs/docs-api/more-information/troubleshooting/)
+
+### 관련 이슈
+
+- [#23 OnlyOffice document.key 관리 로직 개선 필요](https://github.com/taez224/onlyoffice-demo/issues/23)
+
+---
+
+*마지막 업데이트: 2025-12-09*


### PR DESCRIPTION
## Summary

- OnlyOffice 공식 API 스펙에 맞게 document.key 관리 로직 개선
- 편집 세션 종료(status=2) 시 editorVersion 증가하여 새 key 생성
- Force Save(status=6) 시에는 co-editing 세션 유지를 위해 version 유지
- Controller에서 Repository 직접 사용하던 패턴을 Service 계층으로 리팩토링

## Changes

### New Files
- `KeyUtils.java` - document.key 생성/검증 유틸리티 (128자 제한, 특수문자 제거)
- `KeyUtilsTest.java` - KeyUtils 단위 테스트
- `docs/onlyoffice-integration-guide.md` - OnlyOffice 통합 기술 문서

### Modified Files
- `Document.java` - editorVersion 필드 추가, getEditorKey()/incrementEditorVersion() 메서드
- `DocumentRepository.java` - findByFileNameAndDeletedAtIsNull() 추가
- `DocumentService.java` - key 관련 비즈니스 로직 추가
- `EditorController.java` - Service를 통한 key 생성으로 변경
- `CallbackController.java` - Service를 통한 저장/버전 관리로 변경
- `README.md` - 문서 링크 추가

## Test plan

- [x] KeyUtilsTest 통과
- [x] 기존 테스트 통과
- [ ] 실제 OnlyOffice 에디터에서 편집 후 저장 테스트
- [ ] co-editing 시나리오 테스트

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)