### PR TITLE
refactor(backend): optimize indexing, improve soft delete handling, and streamline MIME validation

### DIFF
--- a/backend/src/main/java/com/example/onlyoffice/entity/Document.java
+++ b/backend/src/main/java/com/example/onlyoffice/entity/Document.java
@@ -6,25 +6,22 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import lombok.*;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.NaturalId;
-import org.hibernate.annotations.SoftDelete;
-import org.hibernate.annotations.SoftDeleteType;
-import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.annotations.*;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Entity
 @Table(
-    name = "documents",
-    indexes = {
-        @Index(name = "idx_file_key", columnList = "file_key"),
-        @Index(name = "idx_file_name", columnList = "file_name"),
-        @Index(name = "idx_created_at", columnList = "created_at"),
-        @Index(name = "idx_status", columnList = "status"),
-        @Index(name = "idx_deleted_at", columnList = "deleted_at")
-    }
+        name = "documents",
+        indexes = {
+                // Sorting index
+                @Index(name = "idx_created_at", columnList = "created_at"),
+                // Composite indexes for soft delete query optimization
+                @Index(name = "idx_file_key_deleted_at", columnList = "file_key, deleted_at"),
+                @Index(name = "idx_file_name_deleted_at", columnList = "file_name, deleted_at"),
+                @Index(name = "idx_status_deleted_at", columnList = "status, deleted_at")
+        }
 )
 @SoftDelete(strategy = SoftDeleteType.TIMESTAMP, columnName = "deleted_at")
 @Getter

--- a/backend/src/main/java/com/example/onlyoffice/service/MinioStorageService.java
+++ b/backend/src/main/java/com/example/onlyoffice/service/MinioStorageService.java
@@ -76,7 +76,7 @@ public class MinioStorageService {
 
     /**
      * InputStream을 MinIO에 업로드 (크기가 불명확한 스트림도 지원)
-     * 
+     *
      * <p>재시도 정책: 네트워크 장애 등으로 실패 시 최대 3회 재시도 (1초 간격)</p>
      *
      * @param inputStream 업로드할 InputStream
@@ -138,7 +138,7 @@ public class MinioStorageService {
 
     /**
      * MinIO에서 파일을 삭제
-     * 
+     *
      * <p>재시도 정책: 네트워크 장애 등으로 실패 시 최대 3회 재시도 (1초 간격)</p>
      *
      * @param objectName The object key/path in MinIO

--- a/backend/src/test/java/com/example/onlyoffice/service/DocumentServiceIntegrationTest.java
+++ b/backend/src/test/java/com/example/onlyoffice/service/DocumentServiceIntegrationTest.java
@@ -1,0 +1,117 @@
+package com.example.onlyoffice.service;
+
+import com.example.onlyoffice.entity.Document;
+import com.example.onlyoffice.entity.DocumentStatus;
+import com.example.onlyoffice.exception.DocumentDeleteException;
+import com.example.onlyoffice.repository.DocumentRepository;
+import com.onlyoffice.manager.document.DocumentManager;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("DocumentService 통합 테스트")
+class DocumentServiceIntegrationTest {
+
+    @Autowired
+    private DocumentService documentService;
+
+    @Autowired
+    private DocumentRepository documentRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @MockitoBean
+    private MinioStorageService storageService;
+
+    @MockitoBean
+    private FileSecurityService fileSecurityService;
+
+    @MockitoBean
+    private UrlDownloadService urlDownloadService;
+
+    @MockitoBean
+    private DocumentManager documentManager;
+
+    private Document testDocument;
+
+    @BeforeEach
+    void setUp() {
+        documentRepository.deleteAll();
+
+        testDocument = documentRepository.saveAndFlush(Document.builder()
+                .fileName("rollback-test.docx")
+                .fileKey("rollback-test-key-001")
+                .fileType("docx")
+                .documentType("word")
+                .fileSize(1024L)
+                .storagePath("documents/rollback-test-key-001/rollback-test.docx")
+                .status(DocumentStatus.ACTIVE)
+                .build());
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("스토리지 삭제 성공 시 문서가 soft delete된다")
+    void deleteDocument_softDeletesWhenStorageSucceeds() {
+        // given
+        doNothing().when(storageService).deleteFile(anyString());
+
+        // when
+        documentService.deleteDocument(testDocument.getId());
+        entityManager.flush();
+        entityManager.clear();
+
+        // then: soft deleted 문서는 findById에서 조회되지 않음
+        assertThat(documentRepository.findById(testDocument.getId())).isEmpty();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("스토리지 삭제 실패 시 soft delete가 롤백된다")
+    void deleteDocument_rollsBackSoftDeleteWhenStorageFails() {
+        // given
+        doThrow(new RuntimeException("Storage failure"))
+                .when(storageService).deleteFile(anyString());
+
+        // when & then: 예외 발생
+        assertThatThrownBy(() -> documentService.deleteDocument(testDocument.getId()))
+                .isInstanceOf(DocumentDeleteException.class)
+                .hasMessageContaining("Delete failed");
+
+        // 캐시 클리어하여 DB에서 다시 조회
+        entityManager.clear();
+
+        // then: 문서가 여전히 존재하고 soft delete되지 않았는지 확인
+        Document afterFailure = documentRepository.findById(testDocument.getId()).orElse(null);
+        assertThat(afterFailure).isNotNull();
+        assertThat(afterFailure.getStatus()).isEqualTo(DocumentStatus.ACTIVE);
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("존재하지 않는 문서 삭제 시 예외 발생")
+    void deleteDocument_throwsWhenDocumentNotFound() {
+        // given
+        Long nonExistentId = 999999L;
+
+        // when & then
+        assertThatThrownBy(() -> documentService.deleteDocument(nonExistentId))
+                .isInstanceOf(com.example.onlyoffice.exception.DocumentNotFoundException.class);
+    }
+}


### PR DESCRIPTION
## Summary

- **Document indexes optimized**: Single-column indexes replaced with composite indexes (`file_key_deleted_at`, `file_name_deleted_at`, `status_deleted_at`) for better soft delete query performance
- **Soft delete handling improved**: Removed manual `restore` logic in `DocumentService.delete()`, now relies on `@Transactional` rollback behavior
- **MIME validation streamlined**: Replaced `MimeTypes` with direct `Tika` class usage for simpler, cleaner MIME type detection

## Changes

| File | Description |
|------|-------------|
| `Document.java` | Composite indexes for soft delete optimization |
| `DocumentService.java` | Simplified delete() with @Transactional rollback |
| `FileSecurityService.java` | Tika-based MIME detection, removed MimeTypes/MimeTypeException |
| `MinioStorageService.java` | Minor JavaDoc formatting |

## Test plan

- [ ] Verify document CRUD operations work correctly
- [ ] Confirm soft delete queries use new composite indexes (`EXPLAIN ANALYZE`)
- [ ] Test file upload with various MIME types
- [ ] Verify delete rollback behavior when storage deletion fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)